### PR TITLE
Fix LedDriver.off not working on WROOM based boards

### DIFF
--- a/src/driver/led_driver.py
+++ b/src/driver/led_driver.py
@@ -96,25 +96,14 @@ class LedDriver:
 
 
     def off(self):
-#            print("leds.off() called")
-#        if (config.HARDWARE_CONFIGURATION == 1):
-#            # led OFF
-#            self.led_r.duty(0)
-#            self.led_g.duty(0)
-#            self.led_b.duty(0) 
-#        else:
-            # led OFF
-            self.led_r.duty(0)
-            self.led_g.duty(0)
-            self.led_b.duty(0) 
+        # led OFF
+        self.led_r.duty(self.translate(0))
+        self.led_g.duty(self.translate(0))
+        self.led_b.duty(self.translate(0))
 
-            for i in range(neopixel_num):
-#                print(i)
-                np[i] = (0,0,0)
-            np.write()
-
-
-   
+        for i in range(neopixel_num):
+            np[i] = (0,0,0)
+        np.write()
 
 
     #takes a valur from 0-255 and returns a translated analog out value (1023-a fraction)


### PR DESCRIPTION
The ESP module is the low-side switch to setting the duty cycle to 0 does the opposite of turning the LED off, that is setting it to the brightest possible white.
This commit switches to using the already present `LedDriver.translate` method to not have to care about the actual duty cycle needed for the hardware to turn the LED off.